### PR TITLE
Add proximity operator

### DIFF
--- a/ast/core/operator/proximity.py
+++ b/ast/core/operator/proximity.py
@@ -1,12 +1,12 @@
 """
 core/operator/proximity.py
 
-Proximity analysis for the AST tool. Two analyses live in this module:
+Proximity analysis Operator. Two analyses covered in this operator:
 
-  within_distance — find every feature whose distance to the AOI is
-                    less than or equal to a given radius.
-  nearest         — find the top K closest features (regardless of distance,
-                    with an optional distance cap).
+  within_distance: find every feature whose distance to the AOI is
+                   less than or equal to a given radius.
+  nearest        : find the top K closest features (regardless of distance,
+                   with an optional distance cap).
 
 Both return a list of ProximityResult records sorted by distance ascending.
 
@@ -14,13 +14,15 @@ Notes:
 - The AOI CRS must be projected (metres). Distances are always reported in
   the CRS's native units, which we assume is metres for BC Albers (EPSG:3005).
 - The adapter is called as-is. For Oracle, the caller passes the SDO
-  push-down kwargs (predicate / distance / k / aoi); for local file adapters
-  the full dataset is read and filtered client-side. Push-down support for
+  push-down kwargs (predicate / distance / k / aoi). For local file adapters
+  the full dataset is read and filtered client-side (***This can be very inefficient
+  for large datasets. Looking into usinf bbox/maks for gpd.read()***). Push-down support for
   file adapters is a separate work item
 - gpd.clip via ReadOptions.spatial_mask would alter feature geometries and
   break distance computation, so this module avoids that path entirely.
 """
 
+from geopandas import geodataframe
 from __future__ import annotations
 
 from typing import Any, Iterable
@@ -56,6 +58,9 @@ def within_distance(
         raise ValueError("distance_m must be non-negative")
     _require_projected(aoi)
 
+    # Ask the adapter for the dataset features. 
+    # The orchestrator can pre-tell the adapter how to filter (Oracle uses predicate="within_distance"
+    # file adapters just read everything for now (***will look into this***).
     gdf = adapter.read(
         read_options=read_options or _default_read_options(feature_id_field, keep_properties),
         target_crs=str(aoi.gdf.crs),
@@ -70,6 +75,7 @@ def within_distance(
     gdf = gdf[gdf[_DISTANCE_COL] <= distance_m]
     gdf = gdf.sort_values(_DISTANCE_COL)
 
+    # Hand the sorted rows to _build_results to turn them into the proper ProximityResult records
     return _build_results(gdf, feature_id_field, keep_properties)
 
 
@@ -99,6 +105,8 @@ def nearest(
         raise ValueError("max_distance_m must be non-negative")
     _require_projected(aoi)
 
+    # adapter read. For Oracle the orchestrator can use predicate="nearest" to push the work down to the database
+    # for file adapters we get the full dataset. (***will look into this***).
     gdf = adapter.read(
         read_options=read_options or _default_read_options(feature_id_field, keep_properties),
         target_crs=str(aoi.gdf.crs),
@@ -151,6 +159,14 @@ def _build_results(
     feature_id_field: str | None,
     keep_properties: Iterable[str] | None,
 ) -> list[ProximityResult]:
+    """Turns the filtered/sorted GeoDataFrame into the typed ProximityResult 
+        records the rest of the system expects.
+
+        For each row of the GeoDataFrame it builds one ProximityResult containing:
+            - the distance (pulled from the _proximity_distance_m column)
+            - a FeatureRecord with the feature's ID and a dict of its other properties
+        
+        Returns the full list."""
     if gdf.empty:
         return []
 
@@ -170,6 +186,14 @@ def _build_results(
 
 
 def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str:
+    """Figures out the right ID for a feature.
+
+        Tries in this order:
+        1. If the caller told us which column holds the ID (e.g., "OBJECTID") 
+           and that column exists on this row with a non-null value, use it.
+        2. Otherwise, fall back to the row's positional index ("0", "1", …) so we always have some ID
+    
+    """
     if feature_id_field and feature_id_field in row.index:
         value = row[feature_id_field]
         if value is not None:
@@ -178,6 +202,17 @@ def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str
 
 
 def _extract_properties(row: Any, keep: list[str]) -> dict[str, str | int | float]:
+    """Picks attribute columns to surface on the output record.
+
+       Walks the list of column names the caller asked to keep (e.g., ["PID", "parcel_class"]). For each:
+        - Skip if the column isn't on this row.
+        - Skip if the value is null.
+        - If the value is already a string/int/float, keep it as-is.
+        - Anything else (dates, geometries, etc.), convert to string. 
+           This matches the FeatureRecord.properties type signature.
+
+     Returns a {column_name: value} dict.
+    """
     props: dict[str, str | int | float] = {}
     for col in keep:
         if col not in row.index:

--- a/ast/core/operator/proximity.py
+++ b/ast/core/operator/proximity.py
@@ -1,6 +1,4 @@
 """
-core/operator/proximity.py
-
 Proximity analysis Operator. Two analyses covered in this operator:
 
   within_distance: find every feature whose distance to the AOI is
@@ -15,11 +13,9 @@ Notes:
   the CRS's native units, which we assume is metres for BC Albers (EPSG:3005).
 - The adapter is called as-is. For Oracle, the caller passes the SDO
   push-down kwargs (predicate / distance / k / aoi). For local file adapters
-  the full dataset is read and filtered client-side (***This can be very inefficient
-  for large datasets. Looking into usinf bbox/maks for gpd.read()***). Push-down support for
-  file adapters is a separate work item
+  the dataset is read and filtered client-side 
 - gpd.clip via ReadOptions.spatial_mask would alter feature geometries and
-  break distance computation, so this module avoids that path entirely.
+  break distance computation, so this module avoids that path entirely (for now!).
 """
 
 from __future__ import annotations
@@ -50,8 +46,8 @@ def within_distance(
 
     The caller is responsible for telling the adapter how to filter the candidate
     set. For Oracle pass predicate='within_distance', distance=distance_m,
-    aoi=<aoi_gdf> via adapter_kwargs. For file adapters the full dataset is
-    read (push-down not wired yet).
+    aoi=<aoi_gdf> via adapter_kwargs. For file adapters the dataset is
+    read and filtered.
     """
     if distance_m < 0:
         raise ValueError("distance_m must be non-negative")
@@ -59,7 +55,6 @@ def within_distance(
 
     # Ask the adapter for the dataset features. 
     # The orchestrator can pre-tell the adapter how to filter (Oracle uses predicate="within_distance"
-    # file adapters just read everything for now (***will look into this***).
     gdf = adapter.read(
         read_options=read_options or _default_read_options(feature_id_field, keep_properties),
         target_crs=str(aoi.gdf.crs),
@@ -96,7 +91,7 @@ def nearest(
 
     For Oracle the caller can pass predicate='nearest', k=k, aoi=<aoi_gdf>
     via adapter_kwargs so SDO_NN does the work push-down. For file adapters
-    the full dataset is read and sorted client-side.
+    the dataset is read and sorted client-side.
     """
     if k < 1:
         raise ValueError("k must be at least 1")
@@ -105,7 +100,7 @@ def nearest(
     _require_projected(aoi)
 
     # adapter read. For Oracle the orchestrator can use predicate="nearest" to push the work down to the database
-    # for file adapters we get the full dataset. (***will look into this***).
+    # for file adapters we get the full dataset and sort it.
     gdf = adapter.read(
         read_options=read_options or _default_read_options(feature_id_field, keep_properties),
         target_crs=str(aoi.gdf.crs),
@@ -131,7 +126,7 @@ def _default_read_options(
     """Build a ReadOptions that keeps every column the operator needs downstream.
 
     Without this, passing keep_properties through `keep_columns` causes the base
-    adapter to drop feature_id_field — and the result builder falls back to the
+    adapter to drop feature_id_field, and the result builder falls back to the
     row index. We always include feature_id_field in the keep set.
     """
     if not feature_id_field and not keep_properties:
@@ -145,6 +140,8 @@ def _default_read_options(
 
 
 def _require_projected(aoi: AreaOfInterest) -> None:
+    """Make sure the AOI is in a projected CRS for distance calulcation.
+    """
     crs = aoi.gdf.crs
     if crs is None or not crs.is_projected:
         raise ValueError(
@@ -203,7 +200,7 @@ def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str
 def _extract_properties(row: Any, keep: list[str]) -> dict[str, str | int | float]:
     """Picks attribute columns to surface on the output record.
 
-       Walks the list of column names the caller asked to keep (e.g., ["PID", "parcel_class"]). For each:
+       Walks the list of column names the caller asked to keep. For each:
         - Skip if the column isn't on this row.
         - Skip if the value is null.
         - If the value is already a string/int/float, keep it as-is.

--- a/ast/core/operator/proximity.py
+++ b/ast/core/operator/proximity.py
@@ -1,4 +1,192 @@
 """
-/core/operator/distance.py
-This operator calculates distance between an AOI and the nearest feature in an input layer
+core/operator/proximity.py
+
+Proximity analysis for the AST tool. Two analyses live in this module:
+
+  within_distance — find every feature whose distance to the AOI is
+                    less than or equal to a given radius.
+  nearest         — find the top K closest features (regardless of distance,
+                    with an optional distance cap).
+
+Both return a list of ProximityResult records sorted by distance ascending.
+
+Notes:
+- The AOI CRS must be projected (metres). Distances are always reported in
+  the CRS's native units, which we assume is metres for BC Albers (EPSG:3005).
+- The adapter is called as-is. For Oracle, the caller passes the SDO
+  push-down kwargs (predicate / distance / k / aoi); for local file adapters
+  the full dataset is read and filtered client-side. Push-down support for
+  file adapters is a separate work item
+- gpd.clip via ReadOptions.spatial_mask would alter feature geometries and
+  break distance computation, so this module avoids that path entirely.
 """
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import geopandas as gpd
+
+from ..aoi import AreaOfInterest
+from ..data_adapters.base import BaseSpatialAdapter, ReadOptions
+from ..results import FeatureRecord, ProximityResult
+
+
+_DISTANCE_COL = "_proximity_distance_m"
+
+
+def within_distance(
+    *,
+    aoi: AreaOfInterest,
+    adapter: BaseSpatialAdapter,
+    distance_m: float,
+    feature_id_field: str | None = None,
+    keep_properties: Iterable[str] | None = None,
+    read_options: ReadOptions | None = None,
+    **adapter_kwargs,
+) -> list[ProximityResult]:
+    """Return every feature whose distance to the AOI is <= distance_m, ascending.
+
+    The caller is responsible for telling the adapter how to filter the candidate
+    set. For Oracle pass predicate='within_distance', distance=distance_m,
+    aoi=<aoi_gdf> via adapter_kwargs. For file adapters the full dataset is
+    read (push-down not wired yet).
+    """
+    if distance_m < 0:
+        raise ValueError("distance_m must be non-negative")
+    _require_projected(aoi)
+
+    gdf = adapter.read(
+        read_options=read_options or _default_read_options(feature_id_field, keep_properties),
+        target_crs=str(aoi.gdf.crs),
+        **adapter_kwargs,
+    )
+    if gdf.empty:
+        return []
+
+    aoi_geom = aoi.gdf.geometry.union_all()
+    gdf = gdf.copy()
+    gdf[_DISTANCE_COL] = gdf.geometry.distance(aoi_geom)
+    gdf = gdf[gdf[_DISTANCE_COL] <= distance_m]
+    gdf = gdf.sort_values(_DISTANCE_COL)
+
+    return _build_results(gdf, feature_id_field, keep_properties)
+
+
+def nearest(
+    *,
+    aoi: AreaOfInterest,
+    adapter: BaseSpatialAdapter,
+    k: int = 1,
+    max_distance_m: float | None = None,
+    feature_id_field: str | None = None,
+    keep_properties: Iterable[str] | None = None,
+    read_options: ReadOptions | None = None,
+    **adapter_kwargs,
+) -> list[ProximityResult]:
+    """Return up to k closest features, sorted by distance ascending.
+
+    If max_distance_m is given, candidates beyond that distance are dropped
+    (mirrors the legacy 25 km cap on archaeology sites).
+
+    For Oracle the caller can pass predicate='nearest', k=k, aoi=<aoi_gdf>
+    via adapter_kwargs so SDO_NN does the work push-down. For file adapters
+    the full dataset is read and sorted client-side.
+    """
+    if k < 1:
+        raise ValueError("k must be at least 1")
+    if max_distance_m is not None and max_distance_m < 0:
+        raise ValueError("max_distance_m must be non-negative")
+    _require_projected(aoi)
+
+    gdf = adapter.read(
+        read_options=read_options or _default_read_options(feature_id_field, keep_properties),
+        target_crs=str(aoi.gdf.crs),
+        **adapter_kwargs,
+    )
+    if gdf.empty:
+        return []
+
+    aoi_geom = aoi.gdf.geometry.union_all()
+    gdf = gdf.copy()
+    gdf[_DISTANCE_COL] = gdf.geometry.distance(aoi_geom)
+    if max_distance_m is not None:
+        gdf = gdf[gdf[_DISTANCE_COL] <= max_distance_m]
+    gdf = gdf.sort_values(_DISTANCE_COL).head(k)
+
+    return _build_results(gdf, feature_id_field, keep_properties)
+
+
+def _default_read_options(
+    feature_id_field: str | None,
+    keep_properties: Iterable[str] | None,
+) -> ReadOptions:
+    """Build a ReadOptions that keeps every column the operator needs downstream.
+
+    Without this, passing keep_properties through `keep_columns` causes the base
+    adapter to drop feature_id_field — and the result builder falls back to the
+    row index. We always include feature_id_field in the keep set.
+    """
+    if not feature_id_field and not keep_properties:
+        return ReadOptions()
+    keep: set[str] = set()
+    if feature_id_field:
+        keep.add(feature_id_field)
+    if keep_properties:
+        keep.update(keep_properties)
+    return ReadOptions(keep_columns=keep)
+
+
+def _require_projected(aoi: AreaOfInterest) -> None:
+    crs = aoi.gdf.crs
+    if crs is None or not crs.is_projected:
+        raise ValueError(
+            f"AOI {aoi.aoi_id} must be in a projected CRS for proximity analysis "
+            "(distances are computed in CRS units, expected metres)."
+        )
+
+
+def _build_results(
+    gdf: gpd.GeoDataFrame,
+    feature_id_field: str | None,
+    keep_properties: Iterable[str] | None,
+) -> list[ProximityResult]:
+    if gdf.empty:
+        return []
+
+    keep_list = list(keep_properties) if keep_properties else []
+    results: list[ProximityResult] = []
+    for idx, row in gdf.iterrows():
+        results.append(
+            ProximityResult(
+                nearest_feature_distance=float(row[_DISTANCE_COL]),
+                nearest_feature=FeatureRecord(
+                    feature_id=_extract_feature_id(row, idx, feature_id_field),
+                    properties=_extract_properties(row, keep_list),
+                ),
+            )
+        )
+    return results
+
+
+def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str:
+    if feature_id_field and feature_id_field in row.index:
+        value = row[feature_id_field]
+        if value is not None:
+            return str(value)
+    return str(idx)
+
+
+def _extract_properties(row: Any, keep: list[str]) -> dict[str, str | int | float]:
+    props: dict[str, str | int | float] = {}
+    for col in keep:
+        if col not in row.index:
+            continue
+        value = row[col]
+        if value is None:
+            continue
+        if isinstance(value, (int, float, str)):
+            props[col] = value
+        else:
+            props[col] = str(value)
+    return props

--- a/ast/core/operator/proximity.py
+++ b/ast/core/operator/proximity.py
@@ -22,16 +22,15 @@ Notes:
   break distance computation, so this module avoids that path entirely.
 """
 
-from geopandas import geodataframe
 from __future__ import annotations
 
 from typing import Any, Iterable
 
 import geopandas as gpd
 
-from ..aoi import AreaOfInterest
-from ..data_adapters.base import BaseSpatialAdapter, ReadOptions
-from ..results import FeatureRecord, ProximityResult
+from core.aoi import AreaOfInterest
+from core.data_adapters.base import BaseSpatialAdapter, ReadOptions
+from core.results import FeatureRecord, ProximityResult
 
 
 _DISTANCE_COL = "_proximity_distance_m"

--- a/ast/uv.lock
+++ b/ast/uv.lock
@@ -25,13 +25,17 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "geopandas" },
+    { name = "oracledb" },
     { name = "pydantic" },
+    { name = "shapely" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "geopandas", specifier = ">=1.1.3" },
+    { name = "oracledb", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.13.3" },
+    { name = "shapely", specifier = ">=2.0" },
 ]
 
 [[package]]
@@ -41,6 +45,104 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -111,6 +213,28 @@ wheels = [
 ]
 
 [[package]]
+name = "oracledb"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/3c/79c391788f192c68892b8a8beb3b2d582a87301158de95077344f5ace5ce/oracledb-4.0.0.tar.gz", hash = "sha256:244ebe47c4a4e32bc07a4206192de04d92fbfeb72bf11a01493e3a710bd4b19a", size = 878394, upload-time = "2026-05-04T17:20:49.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/6f/8e44af5f2f5fed3053816550b26d2cb89f94ded13a786e0c5999a45a69e4/oracledb-4.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f5b1f7ae53883336e23a235339e023d26d1d4b0d014ce4944c61dc79951c89df", size = 4328158, upload-time = "2026-05-04T17:21:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/09/7eace2e07af4e5ac6bb5667b8ac1801f4bc921a93d48f6ab7bc05d6141a6/oracledb-4.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80434a5aa393833bfde853e9e2943671cab219b3081c34aad1974df73c21e04d", size = 2282689, upload-time = "2026-05-04T17:21:24.738Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/8d/e6829c60d7d00612163db8efff62c0b4857c7646d8bbc062121cba7671d3/oracledb-4.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:922c59a7fcdc44c93dac852b33b9ebae202614235e0ed235e632bf8d5ca4dd55", size = 2504752, upload-time = "2026-05-04T17:21:27.032Z" },
+    { url = "https://files.pythonhosted.org/packages/87/75/90b9cb4ed563d392885af7cc96a1f23dd4d50a5003aa41d51c2234a28c91/oracledb-4.0.0-cp313-cp313-win32.whl", hash = "sha256:893acd019ee45184e85ef1b5f1ba425ab4da3e8ed4dab1339b7ef329d3658ffc", size = 1502216, upload-time = "2026-05-04T17:21:28.429Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cc/180051d7282a1f213ca46502aea26b9095b053479db5cd391567830cbaa5/oracledb-4.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:997a4cd0f563b5a1aa92aeb9bdd70e67e3789f0d1a418600a7256b27e6c8947f", size = 1844931, upload-time = "2026-05-04T17:21:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/97/52/b57a851a1ace456b294575cd48971f911cf86850f11a7039014802c3eda0/oracledb-4.0.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c65366200b44c0a71b927cd813628f0d993b098c61cc82c54c53bccb0dd0d80", size = 4371890, upload-time = "2026-05-04T17:21:31.82Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/25fbbd4ced440dbb6e04867b9b99557ed7f2f471f172f9ba3eb6fbf68b85/oracledb-4.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6fc3dd6ce0fb1d8ca865bdf39183e663b1dd5e2d585327feffedf379a05e3abb", size = 2322612, upload-time = "2026-05-04T17:21:34.005Z" },
+    { url = "https://files.pythonhosted.org/packages/61/63/d00cc0dbc90f5a6ea7d26c5cc03bb7d949fc37b26ac05e3e7253af50f44a/oracledb-4.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:758ac5a56e872eb517cbae5d28574b200d7b2b28c793ee31b6ce4938777d8364", size = 2527540, upload-time = "2026-05-04T17:21:35.787Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b6/fbfbe12031c96c823e4a6d50744249029069496c9350fa233aa0617499c6/oracledb-4.0.0-cp314-cp314-win32.whl", hash = "sha256:1d3e46c81baf932752d5dfa25e9c63faea65ef17d5c0650558547b8784c929a1", size = 1524343, upload-time = "2026-05-04T17:21:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e0/c229bab86597997139c1c0bf25eae5963113f95c28913c75647d849d96af/oracledb-4.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:cd83db5710e26502352c4ce3f5b5e29f202223f9dade089a28daeb688083d0db", size = 1888636, upload-time = "2026-05-04T17:21:39.498Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -161,6 +285,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
     { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
     { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Add proximity operator (within_distance + nearest)

### What's covered

Two functions in `core/operator/proximity.py`, both returning
`list[ProximityResult]` sorted by distance ascending:

- **`within_distance(aoi, adapter, distance_m, …)`**: returns every feature whose
  distance to the AOI is less than or equal to `distance_m`, driven by the per-dataset `Buffer_Distance`
  column in the input spreadsheets (registery). For BCGW datasets it maps to Oracle's
  `SDO_WITHIN_DISTANCE` push-down.

- **`nearest(aoi, adapter, k=1, max_distance_m=None, …)`**: returns the K closest
  features, regardless of how far they are, with an optional distance cap. The
  legacy tool uses this for **Indian Reserves** on Tab 1 of the output spreadsheet
  (closest reserve, no distance limit) and for **archaeology sites** (closest site,
  25 km cap supported here via `max_distance_m`). For BCGW datasets it maps to
  Oracle's `SDO_NN` push-down.

Plus a few small helpers: `_default_read_options`, `_require_projected`,
`_build_results`, `_extract_feature_id`, `_extract_properties`.

### Design decisions

- **Adapter-agnostic.** The operator takes a `BaseSpatialAdapter` and never looks
  at which kind it is. It computes distances client-side with shapely on
  whatever GeoataFrame the adapter returns. The same function works for
  Oracle, SHP/FGDB adapters (and any future other adapters). Anything source-specific
  (Oracle's `predicate=`, a file adapter's `path=`) is forwarded through
  `**adapter_kwargs`, the operator passes it along without inspecting it.

- **Radius and K come from the caller, not a config object.** `distance_m` /
  `k` are plain function arguments. The orchestrator (not yet implemented) will read these from the
  dataset registry and pass them in. This keeps the operator seperatte from the
  registry shape.

- **The operator does not use `ReadOptions.spatial_mask`.** The base adapter's
  post-filter applies `spatial_mask` with `gpd.clip`, which cuts feature geometries
  at the mask boundary, which corrupt the distance computation (see flag nbr2 below)

- **Projected CRS is required.** Distances only make sense in metres. If the AOI
  is in a geographic CRS (lat/lon), the operator raises a clear `ValueError`
  instead of silently returning distances in degrees. Added this since the AOI module 
  doesent seem to enforce a projected CRS (see flag nbr3).

### Flagged items

Found out oabout these while building the operator. None should block or conflict this PR.

1. **`ProximityResult.nearest_feature`.** This is NOT a bug just a naming thing.
   The field reads like the single-nearest analysis, but `within_distance` emits one `ProximityResult` per
   feature found. Worth either renaming the fields `nearest_feature` → `feature` 
   and `nearest_feature_distance` → `distance_m` for calrity, or adding a separate `WithinDistanceResult` model. 
   Operator code barely changes either way.

2. **`gpd.clip` in `BaseSpatialAdapter._apply_post_filters` alters geometries.**
   Proximity measures distances between the AOI and a feature. To measure correctly you need 
   the whole feature. `clip` cuts features at the mask boundary instead of just selecting them. That
   would break proximity distances . Switching to `gpd.sjoin(..., predicate="intersects")` 
   would select without cutting.

3. **AOI module doesn't enforce a single geometry.** `aoi.gdf` can be one
   row or several depending on `dissolve_mode`. The operator runs `union_all()`
   for distance caculation just to be safe. A  property on `AreaOfInterest` for "the AOI as one
   merged shape" would let operators drop thais enforcemnet ..

4. **AOI module doesn't enforce a projected CRS for metric analyses.**
   `target_crs` can be set to a geographic CRS. The operator sfguards against it with
   `_require_projected`. The AOI module could either refuse non-projected
   `target_crs` for metric work or expose an `is_metric` flag .
