### PR TITLE
Wire describe() into registry enrichment + adapter routing logic

### DIFF
--- a/ast_engine/config/registry/enrichment.py
+++ b/ast_engine/config/registry/enrichment.py
@@ -1,7 +1,9 @@
 import logging
 from .models import BaseDataset, RegistryDataset
+from ...core.data_adapters.base import DatasetInfo
+from ...core.data_adapters.file.adapter import FileSpatialAdapter
+from ...core.data_adapters.oracle.adapter import OracleAdapter
 from typing import Optional
-from pathlib import Path, PureWindowsPath
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -11,8 +13,10 @@ class Enrich():
     TODO: might be nice if enrich had parameters (version: str, dataset_list: List)
     amd returned a Registry
     '''
-    FILE_TYPES=['.gdb','.shp']
-    def __init__(self, base: BaseDataset):
+    # File datasources end in one of these, or carry a path; everything else is
+    # a BCGW table named SCHEMA.TABLE.
+    GEO_EXTENSIONS = (".gdb", ".gpkg", ".shp", ".geojson", ".kml", ".kmz")
+    def __init__(self, base: BaseDataset, connection=None, cursor=None):
         # enrichment state
         self.id: Optional[str]
         self.columns: Optional[list[str]] = None
@@ -22,36 +26,45 @@ class Enrich():
         self.data_adapter: Optional[str] = None
         self.row_count: Optional[int] = None
         self.base = base
+        # A live BCGW connection is only needed to enrich Oracle datasets. The
+        # caller opens one connection and reuses it across every dataset in the
+        # build, the same way the read path does. File datasets ignore it.
+        self.connection = connection
+        self.cursor = cursor
     def resolve_adapter(self):
-        # resolve the data adapter based on the datasource
-        if self.base.datasource.upper().startswith("WHSE"):
+        # File datasources carry a path (slashes) or a known geo file type;
+        # everything else is a BCGW table named SCHEMA.TABLE.
+        ds = self.base.datasource.strip()
+        if "/" in ds or "\\" in ds or ds.lower().endswith(self.GEO_EXTENSIONS):
+            return "FILE"
+        if "." in ds:
             return "ORACLE"
-        else:
-            ds = PureWindowsPath(self.base.datasource)
-            if ds.suffix.lower() in self.FILE_TYPES:
-                return 'FILE'
-            else:
-                if any(part.endswith(ext) for part in ds.parts for ext in self.FILE_TYPES):
-                    return 'FILE'
-                # for part in ds.parts:
-                #     for FILE_TYPE in self.FILE_TYPES:
-                #         if FILE_TYPE in part.lower():
-                #             return 'FILE'
-                raise ValueError('Datasource data adapter could not be resolved')  
+        raise ValueError(f"Could not resolve a data adapter for: {ds!r}")
+    def _set_metadata(self, info: DatasetInfo):
+        # Map the adapter's DatasetInfo onto the enrichment fields. The field
+        # names line up 1:1, and geometry_type is already lowercase
+        # ("point" / "line" / "polygon").
+        self.columns = info.columns
+        self.crs = info.crs
+        self.geom_column = info.geom_column
+        self.geometry_type = info.geometry_type
+        self.row_count = info.row_count
     def enrich_from_file(self):
-        # use the file data adapter to get this info
-        self.columns = ['FOO','BAR']
-        self.crs = 'EPSG:3005'
-        self.geom_column = 'GEOMETRY'
-        self.geometry_type = 'POLYGON'
-        self.row_count = 200
+        # read the file's metadata without loading all of its features
+        info = FileSpatialAdapter().describe(path=self.base.datasource)
+        self._set_metadata(info)
     def enrich_from_oracle(self):
-        # use the oracle data adapter to get this info
-        self.columns = ['FOO','BAR']
-        self.crs = 'EPSG:3005'
-        self.geom_column = 'GEOMETRY'
-        self.geometry_type = 'POLYGON'
-        self.row_count = 400
+        # read the BCGW table's metadata over a live connection
+        if self.connection is None or self.cursor is None:
+            raise ValueError(
+                "Enriching a BCGW (Oracle) dataset needs a live database "
+                "connection. Open an OracleConnection during the build and pass "
+                f"it to Enrich. Dataset: {self.base.datasource!r}"
+            )
+        info = OracleAdapter(self.connection, self.cursor).describe(
+            table=self.base.datasource
+        )
+        self._set_metadata(info)
     def enrich(self):
         '''Resolves data adapter and enriches object with metadata'''
         # TODO: Do we need to somehow enforce unique? or move this up to the 

--- a/ast_engine/config/spreadsheet_ingestion.py
+++ b/ast_engine/config/spreadsheet_ingestion.py
@@ -1,47 +1,74 @@
 '''
+Build the dataset registry from an input spreadsheet.
 
+Reads the statusing input spreadsheet, hydrates BaseDatasets, enriches each one
+with real geometry/CRS/columns/row-count, and writes the result to a registry
+YAML.
+
+Enriching a BCGW (Oracle) dataset reads its metadata over a live database
+connection, so this script opens one OracleConnection and reuses it across every
+dataset (file datasets need no connection). 
+
+Credentials come from the BCGW_USER / BCGW_PASSWORD / BCGW_HOST environment
+variables if set, otherwise the script prompts for them (the password is read
+with getpass so it never echoes ).
 '''
 
 
-from ast_engine.config.registry import enrichment, utils, models
-
+import getpass
+import os
+import sys
 from pathlib import Path
 
-# ingest spreadshet
-
-xlsx_in = "ast_engine/tests/data/Test_Registry.xlsx"
-
-template_dict = {
-    "name": "Featureclass_Name(valid characters only)",
-    "datasource": "Datasource",
-    "aggregate_columns": [
-        "Fields_to_Summarize",
-        "Fields_to_Summarize2",
-        "Fields_to_Summarize3",
-        "Fields_to_Summarize4",
-        "Fields_to_Summarize5",
-        "Fields_to_Summarize6",
-    ],
-    "definition":"Definition_Query",
-}
-
-datasets = utils.ingest_spreadsheet(template_dict, xlsx_in)
-# for value in datasets:
-    # print(value)
-# print(datasets)
-# print(len(datasets))
-
-hydrated = utils.hydrate_base_datasets(datasets)
-# print(hydrated)
+from ast_engine.config.registry import enrichment, utils, models
+from ast_engine.core.data_adapters.oracle import OracleConnection
 
 
-base_datasets_list = []
-for dataset in hydrated:
-    print(dataset)
-    enriched = enrichment.Enrich(dataset)
-    enriched.enrich()
-    base_datasets_list.append(enriched.build())
+def get_credentials() -> tuple[str, str, str]:
+    '''BCGW credentials from the environment, falling back to a prompt.'''
+    user = os.environ.get("BCGW_USER") or input("BCGW username: ").strip()
+    password = os.environ.get("BCGW_PASSWORD") or getpass.getpass("BCGW password: ")
+    host = os.environ.get("BCGW_HOST") or input(
+        "BCGW host/DSN (e.g. bcgw.bcgov:1521/idwprod1.bcgov): "
+    ).strip()
+    if not (user and password and host):
+        sys.exit("Missing BCGW credentials; aborting.")
+    return user, password, host
 
-Registry = models.Registry(version= "0.1", datasets= base_datasets_list)
 
-utils.dump_yaml(Registry, Path("ast_engine/tests/data/Test_Registry.yaml"))
+def main() -> None:
+    xlsx_in = "ast_engine/tests/data/Test_Registry.xlsx"
+
+    template_dict = {
+        "name": "Featureclass_Name(valid characters only)",
+        "datasource": "Datasource",
+        "aggregate_columns": [
+            "Fields_to_Summarize",
+            "Fields_to_Summarize2",
+            "Fields_to_Summarize3",
+            "Fields_to_Summarize4",
+            "Fields_to_Summarize5",
+            "Fields_to_Summarize6",
+        ],
+        "definition": "Definition_Query",
+    }
+
+    datasets = utils.ingest_spreadsheet(template_dict, xlsx_in)
+    hydrated = utils.hydrate_base_datasets(datasets)
+
+    # One BCGW connection, reused to enrich every Oracle dataset in the build.
+    user, password, host = get_credentials()
+    base_datasets_list = []
+    with OracleConnection(user, password, host) as (conn, cursor):
+        for dataset in hydrated:
+            print(dataset)
+            enriched = enrichment.Enrich(dataset, connection=conn, cursor=cursor)
+            enriched.enrich()
+            base_datasets_list.append(enriched.build())
+
+    registry = models.Registry(version="0.1", datasets=base_datasets_list)
+    utils.dump_yaml(registry, Path("ast_engine/tests/data/Test_Registry.yaml"))
+
+
+if __name__ == "__main__":
+    main()

--- a/ast_engine/tests/unit/test_config_registry.py
+++ b/ast_engine/tests/unit/test_config_registry.py
@@ -1,6 +1,15 @@
 from ast_engine.config.registry import enrichment, utils, models
-from pathlib import Path
+from ast_engine.config.registry.models import BaseDataset
+from ast_engine.core.data_adapters.base import DatasetInfo
 
+from pathlib import Path
+from unittest.mock import MagicMock
+import pytest
+
+# Real test data - Test_Shape_A is a single polygon in EPSG:3005 with a "Name"
+# column (same fixtures the adapter tests use).
+DATA_DIR = Path(__file__).parents[1] / "data" / "Test_Shape_A"
+SHP = DATA_DIR / "Test_Shape_A_shp" / "Test_Shape_A.shp"
 
 DATA_DICT = [
         {
@@ -29,12 +38,12 @@ def test_util_hydrate_datasets():
 
 def test_util_load_yaml():
     ''' Test create Registry from yaml
-    '''    
+    '''
     registry = utils.load_yaml(Path('./tests/data/sample_registry.yaml'))
     assert registry.version=="1.0"
     assert len(registry.datasets)==2
     assert registry.datasets[0].crs=="EPSG:3005"
-   
+
 def test_hydrate_base_datasets():
     ''' Test dataset hydration'''
     indata = [DATA_DICT[0]]
@@ -93,3 +102,97 @@ def test_ingest_spreadsheet_to_model():
     data = utils.ingest_spreadsheet(template=template_dict, xlsx_in='./tests/data/Test_Registry.xlsx')
     dsets = utils.hydrate_base_datasets(data)
     assert len(dsets) > 0
+
+
+# ---------------------------------------------------------------------------
+# resolve_adapter - route a datasource to the right adapter by its shape.
+# A path (slash) or a known geo file type is a FILE; SCHEMA.TABLE is ORACLE.
+# This is the routing that used to miss BCGW tables under non-WHSE schemas.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "datasource, expected",
+    [
+        ("WHSE_BASEMAPPING.BCGS_20K_GRID", "ORACLE"),
+        ("WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SP", "ORACLE"),
+        ("REG_LAND_AND_NATURAL_RESOURCE.SOME_TABLE", "ORACLE"),   # non-WHSE schema
+        ("REG_IMAGERY_AND_BASE_MAPS.SOME_LAYER", "ORACLE"),       # non-WHSE schema
+        (r"W:\data\base.gdb\some_layer", "FILE"),                 # gdb + layer
+        ("/data/parcels.shp", "FILE"),                            # flat file with path
+        ("W:/data/cache.gpkg/some_layer", "FILE"),                # gpkg + layer
+        ("Test_Shape_A.kmz", "FILE"),                             # flat file, no path
+    ],
+)
+def test_resolve_adapter_routes(datasource, expected):
+    base = BaseDataset(name="x", datasource=datasource)
+    assert enrichment.Enrich(base).resolve_adapter() == expected
+
+
+@pytest.mark.unit
+def test_resolve_adapter_raises_on_unresolvable():
+    base = BaseDataset(name="x", datasource="just_a_word")
+    with pytest.raises(ValueError):
+        enrichment.Enrich(base).resolve_adapter()
+
+
+# ---------------------------------------------------------------------------
+# enrich() - the file path reads real metadata; the Oracle path is mocked so
+# no database is touched. Both map the adapter's DatasetInfo onto the registry
+# fields and build a RegistryDataset.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_enrich_from_file_real_data():
+    """Enrich a real shapefile end-to-end (no mocks) and build the dataset."""
+    base = BaseDataset(name="Test Shape A", datasource=str(SHP))
+    e = enrichment.Enrich(base)
+    e.enrich()
+
+    assert e.data_adapter == "FILE"
+    assert e.geometry_type == "polygon"
+    assert e.crs == "EPSG:3005"
+    assert "Name" in e.columns
+    assert e.row_count == 1
+
+    dataset = e.build()
+    assert isinstance(dataset, models.RegistryDataset)
+    assert dataset.geom_column == e.geom_column
+    assert dataset.row_count == 1
+
+
+@pytest.mark.unit
+def test_enrich_from_oracle_maps_describe(monkeypatch):
+    """The Oracle path maps describe()'s DatasetInfo onto the registry fields.
+    describe() is patched, so no Oracle connection is used."""
+    info = DatasetInfo(
+        geom_column="SHAPE",
+        crs="EPSG:3005",
+        geometry_type="line",
+        columns=["OBJECTID", "ROAD_NAME"],
+        row_count=99,
+    )
+    monkeypatch.setattr(
+        enrichment.OracleAdapter, "describe", lambda self, *, table: info
+    )
+
+    base = BaseDataset(name="Roads", datasource="WHSE_TRANSPORT.TRANSPORT_LINE")
+    e = enrichment.Enrich(base, connection=MagicMock(), cursor=MagicMock())
+    e.enrich()
+
+    assert e.data_adapter == "ORACLE"
+    assert e.geometry_type == "line"
+    assert e.geom_column == "SHAPE"
+    assert e.row_count == 99
+
+    dataset = e.build()
+    assert dataset.crs == "EPSG:3005"
+    assert dataset.columns == ["OBJECTID", "ROAD_NAME"]
+
+
+@pytest.mark.unit
+def test_enrich_oracle_without_connection_raises():
+    """An Oracle dataset with no connection gives a clear error, not bad data."""
+    base = BaseDataset(name="Roads", datasource="WHSE_TRANSPORT.TRANSPORT_LINE")
+    with pytest.raises(ValueError):
+        enrichment.Enrich(base).enrich()

--- a/ast_engine/tests/unit/test_config_registry.py
+++ b/ast_engine/tests/unit/test_config_registry.py
@@ -52,12 +52,26 @@ def test_hydrate_base_datasets():
     assert dsets[0].name == DATA_DICT[0]["name"]
     assert dsets[0].datasource == DATA_DICT[0]["datasource"]
 
-def test_registry_creation():
+@pytest.mark.unit
+def test_registry_creation(monkeypatch):
     ''' Test registry creation'''
+    # DATA_DICT is all BCGW (Oracle) tables; patch describe() and pass a mock
+    # connection so the build runs offline (no live database).
+    info = DatasetInfo(
+        geom_column="SHAPE",
+        crs="EPSG:3005",
+        geometry_type="polygon",
+        columns=["OBJECTID"],
+        row_count=10,
+    )
+    monkeypatch.setattr(
+        enrichment.OracleAdapter, "describe", lambda self, *, table: info
+    )
+
     dsets = utils.hydrate_base_datasets(DATA_DICT)
     registry_datasets = []
     for d in dsets:
-        enrich_data = enrichment.Enrich(d)
+        enrich_data = enrichment.Enrich(d, connection=MagicMock(), cursor=MagicMock())
         enrich_data.enrich()
         rd = enrich_data.build()
         registry_datasets.append(rd)


### PR DESCRIPTION
Replaces the placeholder enrichment with real metadata, and fixes the Oracle-vs-file routing so all the real datasources resolve.

**Changes**
- Replaced the foo/bar placeholders in enrich_from_file and   _oracle with real adapter describe() calls. Enrich now reads these actual metadata:  geometry coloumn name, geometry type, CRS, columns, row count
- Reading Oracle metadata needs a live BCGW connection, so Enrich now takes caller-owned connection / cursor params. The caller opens one connection and reuses it across all datasets (file datasets need none). An Oracle dataset enriched without a connection raises a clear error instead of writing bad data.
- Modified the resolve_adapter to route by the shape of the datasource. This replaces the placeholder startswith(WHSE)

**Tests**
- New unit tests in test_config_registry.py: routing (incl. the non-WHSE schemas), real-data file enrichment over Test_Shape_A, and Oracle enrichment using a mock connection (same approach as the Oracle adapter tests) so nothing touches the database.
- Updated test_registry_creation to use a mock connection too, and marked it @pytest.mark.unit.