### PR TITLE
Registry operator block

### DIFF
--- a/ast_engine/config/registry/enrichment.py
+++ b/ast_engine/config/registry/enrichment.py
@@ -16,6 +16,10 @@ class Enrich():
     # File datasources end in one of these, or carry a path; everything else is
     # a BCGW table named SCHEMA.TABLE.
     GEO_EXTENSIONS = (".gdb", ".gpkg", ".shp", ".geojson", ".kml", ".kmz")
+    # Feature-id column names to look for, in priority order. OBJECTID should cover
+    # every BCGW table and most file feature classes; FID might be the case for some shapefiles.
+    # If none are present we leave unique_id unset and the operators fall back to the row index.
+    ID_FIELD_CANDIDATES = ("OBJECTID", "FID")
     def __init__(self, base: BaseDataset, connection=None, cursor=None):
         # enrichment state
         self.id: Optional[str]
@@ -77,13 +81,39 @@ class Enrich():
             self.enrich_from_oracle()
         else:
             raise ValueError('Datasource data adapter could not be resolved')    
+    def _resolve_unique_id(self, authored: Optional[str]) -> Optional[str]:
+        # Resolve the feature-id column against the real columns from describe().
+        # An author-set value must be a real column - we return it in the
+        # column's own casing so the operators match it exactly. When it isn't a
+        # column we raise, rather than let it silently fall back to the row index
+        # at run time. With no author value we default to OBJECTID / FID, or None
+        # when neither is present (the operators then use the row index).
+        by_upper = {c.upper(): c for c in (self.columns or [])}
+        if authored:
+            match = by_upper.get(authored.upper())
+            if match is None:
+                raise ValueError(
+                    f"unique_id {authored!r} for dataset {self.base.name!r} is "
+                    f"not a column of {self.base.datasource!r}. Available "
+                    f"columns: {sorted(self.columns or [])}. Leave unique_id "
+                    f"blank to auto-pick OBJECTID / FID."
+                )
+            return match
+        for candidate in self.ID_FIELD_CANDIDATES:
+            if candidate in by_upper:
+                return by_upper[candidate]
+        return None
+
     def build(self) -> RegistryDataset:
         '''
         Builds RegistryDataset from BaseDataset via metadata Enrichment
         '''
-        
+        data = self.base.model_dump(by_alias=True)
+        # Resolve the feature id against the real columns: validate an author-set
+        # value, or default to OBJECTID / FID when blank.
+        data["unique_id"] = self._resolve_unique_id(data.get("unique_id"))
         return RegistryDataset(
-            **self.base.model_dump(by_alias=True),
+            **data,
             id=self.id,
             columns=self.columns,
             geom_column=self.geom_column,

--- a/ast_engine/config/registry/models.py
+++ b/ast_engine/config/registry/models.py
@@ -1,9 +1,48 @@
-from typing import Optional, List, Union
-from pydantic import BaseModel,model_validator,field_validator
+from typing import Optional, List, Union, Literal, Annotated
+from pydantic import BaseModel,model_validator,field_validator,Field
 from .query import WhereClause, LogicalGroup,definition_to_where
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+# --- Operator block --------------------------------------------------------
+# Per dataset: which analysis to run and the parameters it needs. The "type"
+# decides which parameters are valid:
+#   overlay          -> no parameters
+#   within_distance  -> distance_m
+#   nearest          -> k (+ optional max_distance_m)
+#   adjacency        -> tolerance_m
+# These four type names match the orchestrator's analysis names and the
+# operator functions one-to-one (overlay.intersection,
+# proximity.within_distance, proximity.nearest, adjacent.adjacency).
+
+class OverlaySpec(BaseModel):
+    type: Literal["overlay"] = "overlay"
+
+
+class WithinDistanceSpec(BaseModel):
+    type: Literal["within_distance"] = "within_distance"
+    distance_m: float
+
+
+class NearestSpec(BaseModel):
+    type: Literal["nearest"] = "nearest"
+    k: int = 1
+    max_distance_m: Optional[float] = None
+
+
+class AdjacencySpec(BaseModel):
+    type: Literal["adjacency"] = "adjacency"
+    tolerance_m: float = 0.0
+
+
+# the "type" value picks the matching spec above
+OperatorSpec = Annotated[
+    Union[OverlaySpec, WithinDistanceSpec, NearestSpec, AdjacencySpec],
+    Field(discriminator="type"),
+]
+
 
 class BaseDataset(BaseModel):
     # Core identifiers
@@ -16,7 +55,16 @@ class BaseDataset(BaseModel):
     
     # added
     where: Optional[WhereClause | LogicalGroup] = None
-    
+
+    # Which analysis to run + its parameters. Tab 2 fills this from the
+    # Buffer_Distance column at build time; the Tab 1 YAML sets it directly / hardcoded for now.
+    operator: Optional[OperatorSpec] = None
+
+    # Name of the column that uniquely identifies a feature (e.g. OBJECTID /
+    # FID). Normally left blank by the author and filled in during enrichment;
+    # None means the operators fall back to the row index.
+    unique_id: Optional[str] = None
+
     # early ensure aggregate_columns is a list
     @field_validator("aggregate_columns", mode="before")
     @classmethod

--- a/ast_engine/config/registry/models.py
+++ b/ast_engine/config/registry/models.py
@@ -16,6 +16,15 @@ logger = logging.getLogger(__name__)
 # These four type names match the orchestrator's analysis names and the
 # operator functions one-to-one (overlay.intersection,
 # proximity.within_distance, proximity.nearest, adjacent.adjacency).
+#
+# Both registries share this same block, but fill it in differently:
+#   - Tab 2 (spreadsheet) sets it automatically from Buffer_Distance, so it only
+#     ever produces overlay or within_distance.
+#   - Tab 1 (hand-written YAML) sets it directly and can use any of the four
+#     types - nearest and adjacency live here.
+# The block accepts all four types from either source, so adding nearest or
+# adjacency to Tab 2 in the future only means revising the spreadsheet inference
+# (utils.infer_operator), not this model.
 
 class OverlaySpec(BaseModel):
     type: Literal["overlay"] = "overlay"

--- a/ast_engine/config/registry/utils.py
+++ b/ast_engine/config/registry/utils.py
@@ -41,7 +41,11 @@ def infer_operator(buffer_distance) -> dict:
     '''Tab 2 rule: turn the spreadsheet Buffer_Distance into an operator block.
     A blank or zero distance is an overlap (intersect); a positive distance is
     a within_distance buffer of that many metres. This is what keeps the buffer
-    distance out of the dataset name string.'''
+    distance out of the dataset name string.
+
+    Tab 2 only ever yields overlay or within_distance - the spreadsheet carries
+    no k or tolerance. If Tab 2 datasets ever need nearest or adjacency, this is
+    the function to revise (the operator model already supports all four types).'''
     if buffer_distance is None or pd.isna(buffer_distance) or float(buffer_distance) <= 0:
         return {"type": "overlay"}
     return {"type": "within_distance", "distance_m": float(buffer_distance)}

--- a/ast_engine/config/registry/utils.py
+++ b/ast_engine/config/registry/utils.py
@@ -37,6 +37,16 @@ def hydrate_base_datasets(seed: list[dict]) -> list[BaseDataset]:
     return [BaseDataset(**item) for item in seed]
 
 
+def infer_operator(buffer_distance) -> dict:
+    '''Tab 2 rule: turn the spreadsheet Buffer_Distance into an operator block.
+    A blank or zero distance is an overlap (intersect); a positive distance is
+    a within_distance buffer of that many metres. This is what keeps the buffer
+    distance out of the dataset name string.'''
+    if buffer_distance is None or pd.isna(buffer_distance) or float(buffer_distance) <= 0:
+        return {"type": "overlay"}
+    return {"type": "within_distance", "distance_m": float(buffer_distance)}
+
+
 def ingest_spreadsheet(template: dict, inp_xlsx: str) -> list: # Or should the input be xlsx
     '''
     Ingest spreadsheet and create a dictionary to hydrate the base dataset
@@ -61,6 +71,9 @@ def ingest_spreadsheet(template: dict, inp_xlsx: str) -> list: # Or should the i
                         row_dataset[key] = row[value]
                 else:
                     logger.error(f"error {value} is not a string or a list")
+            # Tab 2: derive the operator from the Buffer_Distance column
+            # (blank/0 -> overlap, >0 -> within_distance).
+            row_dataset["operator"] = infer_operator(row.get("Buffer_Distance"))
             # Append dataset to list
             dataset_list.append(row_dataset)
     return dataset_list

--- a/ast_engine/config/spreadsheet_ingestion.py
+++ b/ast_engine/config/spreadsheet_ingestion.py
@@ -51,7 +51,7 @@ def main() -> None:
             "Fields_to_Summarize5",
             "Fields_to_Summarize6",
         ],
-        "definition": "Definition_Query",
+        "definition_query": "Definition_Query",
     }
 
     datasets = utils.ingest_spreadsheet(template_dict, xlsx_in)


### PR DESCRIPTION
Adds the two remaining registry fields the orchestrator needs to run an analysis per dataset: **operator** (which analysis to run) and **unique_id** (the feature id column).

## Files changed

**`config/registry/models.py`**
- Per-dataset `operator` block. The `type` decides the parameters:
  - `overlay`:  no params
  - `within_distance` :  `distance_m`
  - `nearest` : `k` (+ optional `max_distance_m` - distance cap)
  - `adjacency` : `tolerance_m`
  -
- New optional `unique_id` field (the name of the id column). This is a "nice-to-have" - for map linkage and per-feature drill down in the future reporting/mapping components. The tool runs fine without it!

**`config/registry/enrichment.py`**
- `unique_id` is filled in automatically at build time: checks for `OBJECTID` or `FID` if note -> none (none means the operators fall back to the row index).

**`config/registry/utils.py`**
- `infer_operator()`: builds the operator block for Tab 2 datasets from the `Buffer_Distance` column (below).

Logic: Tab 2 datasets get their operator from the spreadsheet's `Buffer_Distance` column at build time:
- blank / 0 ->  `overlay` (intersect)
- greater than 0 -> `within_distance` of that X metres

Tab 2 input spreadsheets cover only `overlay` or `within_distance`.
 `nearest` and `adjacency` come from Tab 1 (hardocded YAML for now). The operator model already supports all four types, so adding nearest/adjacency to Tab 2 in the future only means revising `infer_operator`, not the model itself.

## Out-of-scope

- **Tab 1 YAML**  the hand-written Tab 1 registry (the admin/boundary overlays + arch/IR nearest + survey-parcel adjacency) is not done yet. The operator block will be set directly in the YAML.