### PR TITLE
Results publisher

### DIFF
--- a/ast_engine/config/settings.py
+++ b/ast_engine/config/settings.py
@@ -17,6 +17,12 @@ class Settings(BaseSettings):
     s3_max_retries: int = 5
     s3_retry_mode: Literal["standard"] = "standard"
 
+    # retain spatial results
+    record_spatial: bool = False
+
+    # temporary directory for storing results
+    temp_dir: str | None = None
+    
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/ast_engine/core/execution.py
+++ b/ast_engine/core/execution.py
@@ -42,6 +42,7 @@ from ..utils.diagnostics import DiagnosticTracker
 from ..config.settings import Settings
 
 logger = logging.getLogger(__name__)
+settings = Settings()
 
 # Analysis names, shared 1:1 with the registry operator block (operator.type)
 # and the operator functions.
@@ -236,20 +237,28 @@ def _run_one_task(
     try:
         adapter = _pick_adapter(task, file_adapter, oracle_adapter)
         result = _run_operator(task, aoi, adapter)
+        if settings.record_spatial:
+            _write_spatial(gdf=result.dataframe, 
+                           dataset_id=task.dataset_id, 
+                           dataset_name=task.dataset_name, 
+                           operator_name=task.operator,
+                           output_dir=settings.temp_dir,enabled=settings.record_spatial)
         elapsed = time.perf_counter() - start
         timings.append((task.dataset_name, elapsed))
+
         tracker.log(
             "dataset_done",
             dataset=task.dataset_name,
             operator=task.operator,
             source=task.source_type,
-            features=result.feature_count,
+            features=result.result.feature_count,
             seconds=round(elapsed, 3),
         )
+
         return DatasetResultGroup(
             dataset_id=task.dataset_id,
             dataset_name=task.dataset_name,
-            results=[result],
+            results=[result.result],
         )
     except Exception:
         elapsed = time.perf_counter() - start
@@ -299,7 +308,7 @@ def _source_kwargs(task: AnalysisTask) -> dict[str, str]:
     return {"path": task.datasource}
 
 
-def _run_operator(task: AnalysisTask, aoi: AreaOfInterest, adapter: BaseSpatialAdapter) -> AnalysisResult:
+def _run_operator(task: AnalysisTask, aoi: AreaOfInterest, adapter: BaseSpatialAdapter) -> OperatorOutcome:
     """Dispatch a task to its operator and return the typed result.
 
     The orchestrator passes params + ids + the attribute filter; each operator

--- a/ast_engine/core/execution.py
+++ b/ast_engine/core/execution.py
@@ -29,14 +29,17 @@ import logging
 import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
+from pathlib import Path
+import geopandas as gpd
 
 from .aoi import AreaOfInterest
 from .data_adapters.base import BaseSpatialAdapter
 from .data_adapters.file.adapter import FileSpatialAdapter
 from .data_adapters.oracle import OracleAdapter, OracleConnection
 from .operator import adjacent, overlay, proximity
-from .results import AnalysisResult, AstResults, DatasetResultGroup
+from .results import AnalysisResult, AstResults, DatasetResultGroup, OperatorOutcome
 from ..utils.diagnostics import DiagnosticTracker
+from ..config.settings import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -337,3 +340,10 @@ def _log_timing_summary(timings: list[tuple[str, float]], tracker: DiagnosticTra
         total_seconds=round(total, 2),
         slowest=[(name, round(seconds, 3)) for name, seconds in slowest],
     )
+
+def _write_spatial(gdf: gpd.GeoDataFrame, dataset_id: str, dataset_name: str, operator_name: str, output_dir: str, enabled:bool):
+    if not enabled or not output_dir:
+        return None
+    path = Path(output_dir) / operator_name / f"{dataset_name}.gpkg"
+    gdf.to_file(path, driver="GPKG")
+    return str(path)

--- a/ast_engine/core/execution.py
+++ b/ast_engine/core/execution.py
@@ -19,13 +19,14 @@ concatenated in order (see build_tasks).
 The driver itself (run_analysis) has no knowledge of the registry: it takes a
 list of AnalysisTask and a built AreaOfInterest, picks the right adapter per task,
 calls the operator, and records one DatasetResultGroup per dataset. One dataset's
-failure is logged and recorded as an empty group - the run continues, because a
-real run covers 100-200 datasets per AOI.
+failure is logged and recorded as an empty group marked failed - the run
+continues, because a real run covers 100-200 datasets per AOI.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
@@ -37,12 +38,11 @@ from .data_adapters.base import BaseSpatialAdapter
 from .data_adapters.file.adapter import FileSpatialAdapter
 from .data_adapters.oracle import OracleAdapter, OracleConnection
 from .operator import adjacent, overlay, proximity
-from .results import AnalysisResult, AstResults, DatasetResultGroup, OperatorOutcome
+from .results import AstResults, DatasetResultGroup, OperatorOutcome
 from ..utils.diagnostics import DiagnosticTracker
 from ..config.settings import Settings
 
 logger = logging.getLogger(__name__)
-settings = Settings()
 
 # Analysis names, shared 1:1 with the registry operator block (operator.type)
 # and the operator functions.
@@ -173,6 +173,7 @@ def run_analysis(
     job_id: str,
     oracle_connection: Optional[OracleConnection] = None,
     tracker: Optional[DiagnosticTracker] = None,
+    settings: Optional[Settings] = None,
 ) -> AstResults:
     """Run every task for one AOI and return the assembled AstResults.
 
@@ -185,16 +186,20 @@ def run_analysis(
 
     Per-dataset timings are logged through the DiagnosticTracker so a run can be
     profiled (which datasets are slow, where parallelism would help).
+
+    settings is read once per run. Pass your own to control where the spatial
+    output goes (record_spatial / temp_dir); the default reads the .env file.
     """
     tasks = list(tasks)
     tracker = tracker or DiagnosticTracker()
+    settings = settings or Settings()
     file_adapter = FileSpatialAdapter()
     oracle_adapter = _oracle_adapter(tasks, oracle_connection)
 
     timings: list[tuple[str, float]] = []
     tracker.log("run_start", job_id=job_id, aoi_id=aoi.aoi_id, task_count=len(tasks))
     groups = [
-        _run_one_task(task, aoi, file_adapter, oracle_adapter, tracker, timings)
+        _run_one_task(task, aoi, file_adapter, oracle_adapter, tracker, timings, settings)
         for task in tasks
     ]
     _log_timing_summary(timings, tracker)
@@ -228,21 +233,43 @@ def _run_one_task(
     oracle_adapter: Optional[OracleAdapter],
     tracker: DiagnosticTracker,
     timings: list[tuple[str, float]],
+    settings: Settings,
 ) -> DatasetResultGroup:
     """Run one task and wrap its result in a DatasetResultGroup.
 
-    A failure is logged and recorded as an empty group so the run continues.
+    A failure is logged and recorded as an empty group marked status="failure" so
+    the run continues. The status is what tells a dataset that failed apart from
+    one that ran and found nothing near the AOI - both come back with no results.
+
+    The operator hands back its matched features alongside the result. When
+    record_spatial is on they are saved here, one dataset at a time, and the file
+    path is recorded on the result as spatial_link. The features are dropped as
+    soon as the task ends, so only one dataset's geometry is ever held in memory.
     """
     start = time.perf_counter()
     try:
         adapter = _pick_adapter(task, file_adapter, oracle_adapter)
-        result = _run_operator(task, aoi, adapter)
+        outcome = _run_operator(task, aoi, adapter)
+        result = outcome.result
+
         if settings.record_spatial:
-            _write_spatial(gdf=result.dataframe, 
-                           dataset_id=task.dataset_id, 
-                           dataset_name=task.dataset_name, 
-                           operator_name=task.operator,
-                           output_dir=settings.temp_dir,enabled=settings.record_spatial)
+            write_start = time.perf_counter()
+            result.spatial_link = _write_spatial(
+                gdf=outcome.dataframe,
+                dataset_name=task.dataset_name,
+                operator_name=task.operator,
+                output_dir=settings.temp_dir,
+            )
+            # Only logged when a file was actually written - a dataset with no
+            # matches, or a write that failed, records nothing.
+            if result.spatial_link:
+                tracker.log(
+                    "spatial_written",
+                    dataset=task.dataset_name,
+                    path=result.spatial_link,
+                    seconds=round(time.perf_counter() - write_start, 3),
+                )
+
         elapsed = time.perf_counter() - start
         timings.append((task.dataset_name, elapsed))
 
@@ -251,16 +278,17 @@ def _run_one_task(
             dataset=task.dataset_name,
             operator=task.operator,
             source=task.source_type,
-            features=result.result.feature_count,
+            features=result.feature_count,
             seconds=round(elapsed, 3),
         )
 
         return DatasetResultGroup(
             dataset_id=task.dataset_id,
             dataset_name=task.dataset_name,
-            results=[result.result],
+            status=outcome.status,
+            results=[result],
         )
-    except Exception:
+    except Exception as exc:
         elapsed = time.perf_counter() - start
         timings.append((task.dataset_name, elapsed))
         logger.exception(
@@ -278,6 +306,8 @@ def _run_one_task(
         return DatasetResultGroup(
             dataset_id=task.dataset_id,
             dataset_name=task.dataset_name,
+            status="failure",
+            error=f"{type(exc).__name__}: {exc}",
             results=[],
         )
 
@@ -350,9 +380,40 @@ def _log_timing_summary(timings: list[tuple[str, float]], tracker: DiagnosticTra
         slowest=[(name, round(seconds, 3)) for name, seconds in slowest],
     )
 
-def _write_spatial(gdf: gpd.GeoDataFrame, dataset_id: str, dataset_name: str, operator_name: str, output_dir: str, enabled:bool):
-    if not enabled or not output_dir:
+def _write_spatial(
+    gdf: Optional[gpd.GeoDataFrame],
+    dataset_name: str,
+    operator_name: str,
+    output_dir: Optional[str],
+) -> Optional[str]:
+    """Save one dataset's matched features as a GeoPackage; return the path, or None.
+
+    Files are grouped by analysis: <output_dir>/<operator>/<dataset name>.gpkg. One
+    file per dataset rather than one shared GeoPackage, so parallel workers never
+    write to the same file. Nothing is written when the output folder is not set or
+    the dataset matched no features.
+
+    A write that fails is logged and skipped: a missing file must never cost a good
+    analysis result.
+    """
+    if not output_dir or gdf is None or gdf.empty:
         return None
-    path = Path(output_dir) / operator_name / f"{dataset_name}.gpkg"
-    gdf.to_file(path, driver="GPKG")
+
+    path = Path(output_dir) / operator_name / f"{_safe_filename(dataset_name)}.gpkg"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        gdf.to_file(path, driver="GPKG")
+    except Exception:
+        logger.exception("Could not save the spatial output for dataset %r", dataset_name)
+        return None
     return str(path)
+
+
+def _safe_filename(name: str) -> str:
+    """Make a dataset name usable as a file name.
+
+    Registry names can -carry spaces, brackets and slashes; anything that is not a
+    letter, number, dash or underscore becomes an underscore.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9_-]+", "_", name).strip("_")
+    return cleaned or "dataset"

--- a/ast_engine/core/execution.py
+++ b/ast_engine/core/execution.py
@@ -259,6 +259,7 @@ def _run_one_task(
                 dataset_name=task.dataset_name,
                 operator_name=task.operator,
                 output_dir=settings.temp_dir,
+                source_registry=task.source_registry,
             )
             # Only logged when a file was actually written - a dataset with no
             # matches, or a write that failed, records nothing.
@@ -385,13 +386,22 @@ def _write_spatial(
     dataset_name: str,
     operator_name: str,
     output_dir: Optional[str],
+    source_registry: Optional[str] = None,
 ) -> Optional[str]:
     """Save one dataset's matched features as a GeoPackage; return the path, or None.
 
-    Files are grouped by analysis: <output_dir>/<operator>/<dataset name>.gpkg. One
-    file per dataset rather than one shared GeoPackage, so parallel workers never
-    write to the same file. Nothing is written when the output folder is not set or
-    the dataset matched no features.
+    Files are grouped by registry and then by analysis:
+    <output_dir>/<registry>/<operator>/<dataset name>.gpkg. One file per dataset
+    rather than one shared GeoPackage, so parallel workers never write to the same
+    file. Nothing is written when the output folder is not set or the dataset
+    matched no features.
+
+    The registry folder is what keeps two datasets apart when they share a name.
+    That happens for real: Tab 1 is a curated selection of datasets that also
+    appear in the provincial registry, so a run covering both carries the same
+    dataset name twice. Without the registry in the path they both write to one
+    file, the second silently replaces the first, and both results point at
+    whatever survived. Tasks built by hand (no registry) keep the shorter path.
 
     A write that fails is logged and skipped: a missing file must never cost a good
     analysis result.
@@ -399,7 +409,10 @@ def _write_spatial(
     if not output_dir or gdf is None or gdf.empty:
         return None
 
-    path = Path(output_dir) / operator_name / f"{_safe_filename(dataset_name)}.gpkg"
+    folder = Path(output_dir)
+    if source_registry:
+        folder = folder / _safe_filename(source_registry)
+    path = folder / operator_name / f"{_safe_filename(dataset_name)}.gpkg"
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         gdf.to_file(path, driver="GPKG")

--- a/ast_engine/core/operator/adjacent.py
+++ b/ast_engine/core/operator/adjacent.py
@@ -84,11 +84,13 @@ def adjacency(
         **source_kwargs,
     )
     if gdf.empty:
-        return AdjacencyResult(is_adjacent=False, features=[])
+        # Nothing read is still a successful run: no features, no geometry to save.
+        return OperatorOutcome(status="success", result=AdjacencyResult(is_adjacent=False, features=[]), dataframe=gdf)
 
     gdf = _clean_geometries(gdf)
     if gdf.empty:
-        return AdjacencyResult(is_adjacent=False, features=[])
+        # Every candidate was dropped as unusable geometry - same as nothing read.
+        return OperatorOutcome(status="success", result=AdjacencyResult(is_adjacent=False, features=[]), dataframe=gdf)
 
     # Dissolve the AOI so a boundary shared between two of its parts is not
     # counted; each dataset feature is then measured against it on its own, which
@@ -121,11 +123,13 @@ def _build_result(
     """
     keep_list = list(keep_properties) if keep_properties else []
     features = []
+    matched_rows = []
     for idx, row in gdf.iterrows():
         shared_lines = _merge_shared_lines(row.geometry.boundary.intersection(match_target))
         length = sum(line.length for line in shared_lines)
         if length <= 0:
             continue
+        matched_rows.append(idx)
         features.append(
             FeatureRecord(
                 feature_id=_extract_feature_id(row, idx, feature_id_field),
@@ -135,9 +139,20 @@ def _build_result(
         )
 
     features.sort(key=lambda feature: feature.measure, reverse=True)
-    # TODO: handle failures with status = 'failure'
-    result = OperatorOutcome(status="success",result=AdjacencyResult(is_adjacent=bool(features), features=features),dataframe=gdf)
-    return result
+
+    # Keep only the features that really share a border. The adapter's search is a
+    # rough first pass, so the frame still holds candidates that turned out not to
+    # be adjacent - a polygon touching the AOI at a single corner, for example. The
+    # frame is saved to disk, so it has to show the same features the result reports.
+    gdf = gdf.loc[matched_rows]
+    # A failure raises out of the operator, so reaching here always means success.
+    # dataframe carries the matched features as they were read (no clipping) so the
+    # orchestrator can save them; it is dropped once written.
+    return OperatorOutcome(
+        status="success",
+        result=AdjacencyResult(is_adjacent=bool(features), features=features),
+        dataframe=gdf,
+    )
 
 
 def _default_read_options(

--- a/ast_engine/core/operator/adjacent.py
+++ b/ast_engine/core/operator/adjacent.py
@@ -39,7 +39,7 @@ from shapely.geometry import LineString, MultiLineString, GeometryCollection
 
 from ..aoi import AreaOfInterest
 from ..data_adapters.base import BaseSpatialAdapter, ReadOptions, SpatialFilter
-from ..results import AdjacencyResult, FeatureRecord
+from ..results import AdjacencyResult, FeatureRecord, OperatorOutcome
 
 try:
     from shapely.validation import make_valid
@@ -57,7 +57,7 @@ def adjacency(
     where: Any = None,
     read_options: ReadOptions | None = None,
     **source_kwargs,
-) -> AdjacencyResult:
+) -> OperatorOutcome:
     """Return one AdjacencyResult for the dataset, features sorted by shared length descending.
 
     tolerance_m chooses the match: 0 is a true touch (exact shared edge), above 0
@@ -110,7 +110,7 @@ def _build_result(
     match_target,
     feature_id_field: str | None,
     keep_properties: Iterable[str] | None,
-) -> AdjacencyResult:
+) -> OperatorOutcome:
     """Turn the cleaned rows into one AdjacencyResult, longest shared border first.
 
     Each feature's shared boundary is merged into clean segments and its length
@@ -135,7 +135,9 @@ def _build_result(
         )
 
     features.sort(key=lambda feature: feature.measure, reverse=True)
-    return AdjacencyResult(is_adjacent=bool(features), features=features)
+    # TODO: handle failures with status = 'failure'
+    result = OperatorOutcome(status="success",result=AdjacencyResult(is_adjacent=bool(features), features=features),dataframe=gdf)
+    return result
 
 
 def _default_read_options(

--- a/ast_engine/core/operator/overlay.py
+++ b/ast_engine/core/operator/overlay.py
@@ -36,6 +36,7 @@ from ..results import (
     LineOverlayResult,
     PointOverlayResult,
     PolyOverlayResult,
+    OperatorOutcome,
 )
 
 _MEASURE_COL = "_overlay_measure"
@@ -53,7 +54,7 @@ def intersection(
     where: Any = None,
     read_options: ReadOptions | None = None,
     **source_kwargs,
-) -> PointOverlayResult | LineOverlayResult | PolyOverlayResult:
+) -> OperatorOutcome:
     """Return one overlay result for the dataset, features sorted by overlap descending.
 
     geom_type, when given (from the dataset registry), selects the result type and
@@ -116,7 +117,7 @@ def _build_result(
     kind: GeomKind,
     feature_id_field: str | None,
     keep_properties: Iterable[str] | None,
-) -> PointOverlayResult | LineOverlayResult | PolyOverlayResult:
+) -> OperatorOutcome:
     """Turn the filtered/sorted rows into one typed overlay result.
 
     Polygons/lines carry a per-feature `measure` (their own overlap) and a
@@ -136,11 +137,19 @@ def _build_result(
 
     if kind == "polygon":
         total = float(gdf[_MEASURE_COL].sum()) if not gdf.empty else 0.0
-        return PolyOverlayResult(features=features, total_area=total)
-    if kind == "line":
+        overlay_result = PolyOverlayResult(features=features, total_area=total)
+    elif kind == "line":
         total = float(gdf[_MEASURE_COL].sum()) if not gdf.empty else 0.0
-        return LineOverlayResult(features=features, total_length=total)
-    return PointOverlayResult(features=features)
+        overlay_result =  LineOverlayResult(features=features, total_length=total)
+    else:
+        overlay_result = None
+    # TODO: handle failures with status = 'failure'
+    if overlay_result is None:
+        result = OperatorOutcome(status="success",result=overlay_result,dataframe=gdf)
+    else:
+        result = OperatorOutcome(status="failed",result=overlay_result,dataframe=gdf)
+    return result
+    
 
 
 def _empty_result(kind: GeomKind) -> PointOverlayResult | LineOverlayResult | PolyOverlayResult:

--- a/ast_engine/core/operator/overlay.py
+++ b/ast_engine/core/operator/overlay.py
@@ -81,7 +81,8 @@ def intersection(
     # the geometries the adapter actually returned.
     kind = geom_type if geom_type in ("point", "line", "polygon") else _infer_geom_kind(gdf)
     if gdf.empty:
-        return _empty_result(kind)
+        # Nothing read is still a successful run: no features, no geometry to save.
+        return OperatorOutcome(status="success", result=_empty_result(kind), dataframe=gdf)
 
     aoi_geom = aoi.gdf.geometry.union_all()
     gdf = gdf.copy()
@@ -140,16 +141,37 @@ def _build_result(
         overlay_result = PolyOverlayResult(features=features, total_area=total)
     elif kind == "line":
         total = float(gdf[_MEASURE_COL].sum()) if not gdf.empty else 0.0
-        overlay_result =  LineOverlayResult(features=features, total_length=total)
+        overlay_result = LineOverlayResult(features=features, total_length=total)
     else:
-        overlay_result = None
-    # TODO: handle failures with status = 'failure'
-    if overlay_result is None:
-        result = OperatorOutcome(status="success",result=overlay_result,dataframe=gdf)
-    else:
-        result = OperatorOutcome(status="failed",result=overlay_result,dataframe=gdf)
-    return result
-    
+        overlay_result = PointOverlayResult(features=features)
+
+    # A failure raises out of the operator, so reaching here always means success.
+    # dataframe carries the matched features as they were read (no clipping) so the
+    # orchestrator can save them; it is dropped once written.
+    return OperatorOutcome(
+        status="success",
+        result=overlay_result,
+        dataframe=_report_measure_column(gdf, kind),
+    )
+
+
+def _report_measure_column(gdf: gpd.GeoDataFrame, kind: GeomKind) -> gpd.GeoDataFrame:
+    """Give the working overlap column a name for the saved GeoPackage, or drop it.
+
+    _MEASURE_COL is this operator's own scratch column. It used to disappear with
+    the frame, but the frame is now saved to disk, so the column ends up in the
+    GeoPackage - it needs a name that says what the number is. 
+    Renamed here rather than by the orchestrator, so the column 
+    name stays private to the operator that created it.
+
+    Points are dropped instead of renamed: their measure is only a 1/0 "inside the
+    AOI" flag used to filter, and every saved point is inside by definition.
+    """
+    if kind == "polygon":
+        return gdf.rename(columns={_MEASURE_COL: "overlap_area_m2"})
+    if kind == "line":
+        return gdf.rename(columns={_MEASURE_COL: "overlap_length_m"})
+    return gdf.drop(columns=[_MEASURE_COL])
 
 
 def _empty_result(kind: GeomKind) -> PointOverlayResult | LineOverlayResult | PolyOverlayResult:

--- a/ast_engine/core/operator/proximity.py
+++ b/ast_engine/core/operator/proximity.py
@@ -47,7 +47,7 @@ def within_distance(
     where: Any = None,
     read_options: ReadOptions | None = None,
     **source_kwargs,
-) -> ProximityResult:
+) -> OperatorOutcome:
     """Return one ProximityResult holding every feature within distance_m, nearest first.
 
     The default ReadOptions pushes a SpatialFilter(predicate='within_distance',
@@ -73,7 +73,8 @@ def within_distance(
         **source_kwargs,
     )
     if gdf.empty:
-        return ProximityResult(features=[])
+        # Nothing read is still a successful run: no features, no geometry to save.
+        return OperatorOutcome(status="success", result=ProximityResult(features=[]), dataframe=gdf)
 
     aoi_geom = aoi.gdf.geometry.union_all()
     gdf = gdf.copy()
@@ -126,7 +127,8 @@ def nearest(
         **source_kwargs,
     )
     if gdf.empty:
-        return ProximityResult(features=[])
+        # Nothing read is still a successful run: no features, no geometry to save.
+        return OperatorOutcome(status="success", result=ProximityResult(features=[]), dataframe=gdf)
 
     aoi_geom = aoi.gdf.geometry.union_all()
     gdf = gdf.copy()
@@ -192,9 +194,17 @@ def _build_results(
         )
         for idx, row in gdf.iterrows()
     ]
-    # TODO: handle failures with status = 'failure'
-    result = OperatorOutcome(status="success",result=ProximityResult(features=features),dataframe=gdf)
-    return result
+    # _DISTANCE_COL is this operator's own scratch column. It used to disappear
+    # with the frame, but the frame is now saved to disk, so it ends up in the
+    # GeoPackage an analyst opens - it needs a name that says what the number is.
+    # Renamed here rather than by the orchestrator, so the
+    # column name stays private to the operator that created it.
+    gdf = gdf.rename(columns={_DISTANCE_COL: "distance_to_aoi_m"})
+
+    # A failure raises out of the operator, so reaching here always means success.
+    # dataframe carries the matched features as they were read (no clipping) so the
+    # orchestrator can save them; it is dropped once written.
+    return OperatorOutcome(status="success", result=ProximityResult(features=features), dataframe=gdf)
 
 
 def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str:

--- a/ast_engine/core/operator/proximity.py
+++ b/ast_engine/core/operator/proximity.py
@@ -31,7 +31,7 @@ import pandas as pd
 
 from ast_engine.core.aoi import AreaOfInterest
 from ast_engine.core.data_adapters.base import BaseSpatialAdapter, ReadOptions, SpatialFilter
-from ast_engine.core.results import FeatureRecord, ProximityResult
+from ast_engine.core.results import FeatureRecord, ProximityResult, OperatorOutcome
 
 
 _DISTANCE_COL = "_proximity_distance_m"
@@ -96,7 +96,7 @@ def nearest(
     where: Any = None,
     read_options: ReadOptions | None = None,
     **source_kwargs,
-) -> ProximityResult:
+) -> OperatorOutcome:
     """Return one ProximityResult holding up to k closest features, nearest first.
 
     If max_distance_m is given, candidates beyond that distance are dropped
@@ -175,7 +175,7 @@ def _build_results(
     gdf: gpd.GeoDataFrame,
     feature_id_field: str | None,
     keep_properties: Iterable[str] | None,
-) -> ProximityResult:
+) -> OperatorOutcome:
     """Turn the filtered/sorted GeoDataFrame into a single ProximityResult.
 
         Each matched feature becomes one FeatureRecord whose `measure` is its
@@ -192,7 +192,9 @@ def _build_results(
         )
         for idx, row in gdf.iterrows()
     ]
-    return ProximityResult(features=features)
+    # TODO: handle failures with status = 'failure'
+    result = OperatorOutcome(status="success",result=ProximityResult(features=features),dataframe=gdf)
+    return result
 
 
 def _extract_feature_id(row: Any, idx: Any, feature_id_field: str | None) -> str:

--- a/ast_engine/core/results.py
+++ b/ast_engine/core/results.py
@@ -102,6 +102,12 @@ class OperatorOutcome(BaseModel):
 class DatasetResultGroup(BaseModel):
     dataset_id: str
     dataset_name: str
+    # did this dataset run? set by the orchestrator, not the operator. Tells a
+    # dataset that failed apart from one that ran and found nothing - both come
+    # back with no results.
+    status: Literal["success", "failure"] = "success"
+    # why it failed; empty when the dataset ran
+    error: str | None = None
     results: List[AnalysisResult]
 
 class AstResults(BaseModel):

--- a/ast_engine/core/results.py
+++ b/ast_engine/core/results.py
@@ -7,7 +7,8 @@ from datetime import datetime, UTC
 from enum import Enum
 from functools import partial
 from typing import List, Union, Literal, Annotated, Dict
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, ConfigDict
+import geopandas as gpd
 
 class FeatureRecord(BaseModel):
     # non-spatial record
@@ -90,6 +91,14 @@ AnalysisResult = Annotated[
     Union[PointOverlayResult, LineOverlayResult, PolyOverlayResult, AdjacencyResult, ProximityResult],
     Field(discriminator="operator_type")
 ]
+
+class OperatorOutcome(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    status: Literal["success", "failure"]
+    result: AnalysisResult | None = None
+    dataframe: gpd.GeoDataFrame | None = None
+
 class DatasetResultGroup(BaseModel):
     dataset_id: str
     dataset_name: str

--- a/ast_engine/tests/unit/test_adjacent.py
+++ b/ast_engine/tests/unit/test_adjacent.py
@@ -18,6 +18,9 @@ What we check:
   IDs and kept columns;
 - bad input (negative tolerance) and a lat/long AOI are rejected;
 - the operator asks the source for the right search (touches vs within_distance).
+
+Note: the operator returns an OperatorOutcome - the analysis result plus the
+features it was built from - so these tests read `.result` off the call.
 """
 
 import pytest
@@ -92,7 +95,7 @@ def test_shares_full_edge_is_adjacent():
     aoi = _valid_aoi()
     minx, miny, maxx, maxy = aoi.gdf.total_bounds
     poly = Polygon([(maxx, miny), (maxx + 500, miny), (maxx + 500, maxy), (maxx, maxy)])
-    result = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0)
+    result = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0).result
     assert result.is_adjacent is True
     assert result.measure_value == pytest.approx(maxy - miny)  # the AOI's height
 
@@ -102,7 +105,7 @@ def test_corner_touch_not_adjacent():
     aoi = _valid_aoi()
     minx, miny, maxx, maxy = aoi.gdf.total_bounds
     poly = Polygon([(maxx, maxy), (maxx + 500, maxy), (maxx + 500, maxy + 500), (maxx, maxy + 500)])
-    result = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0)
+    result = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0).result
     assert result.is_adjacent is False
     assert result.measure_value == 0.0
 
@@ -112,17 +115,36 @@ def test_sliver_gap_missed_at_zero_caught_with_tolerance():
     aoi = _valid_aoi()
     minx, miny, maxx, maxy = aoi.gdf.total_bounds
     poly = Polygon([(maxx + 0.3, miny), (maxx + 500, miny), (maxx + 500, maxy), (maxx + 0.3, maxy)])
-    exact = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0)
-    tolerant = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0.5)
+    exact = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0).result
+    tolerant = adjacency(aoi=aoi, adapter=FakeAdapter(_gdf([poly])), tolerance_m=0.5).result
     assert exact.is_adjacent is False
     assert tolerant.is_adjacent is True
 
 
 def test_empty_dataset_not_adjacent():
     """Nothing comes back from the source -> not adjacent."""
-    result = adjacency(aoi=_valid_aoi(), adapter=FakeAdapter(), tolerance_m=0)
+    result = adjacency(aoi=_valid_aoi(), adapter=FakeAdapter(), tolerance_m=0).result
     assert result.is_adjacent is False
     assert result.feature_count == 0
+
+
+def test_saved_features_match_the_result():
+    """The features handed over for saving are the adjacent ones only.
+
+    The source's search is a rough first pass: the corner-touch box comes back as a
+    candidate but shares no border, so it must not end up in the saved file.
+    """
+    aoi = _valid_aoi()
+    minx, miny, maxx, maxy = aoi.gdf.total_bounds
+    edge = Polygon([(minx, maxy), (maxx, maxy), (maxx, maxy + 300), (minx, maxy + 300)])
+    corner = Polygon([(maxx, maxy), (maxx + 300, maxy), (maxx + 300, maxy + 300), (maxx, maxy + 300)])
+    gdf = _gdf([edge, corner], Id=[1, 2], Name=["edge", "corner"])
+
+    outcome = adjacency(aoi=aoi, adapter=FakeAdapter(gdf), tolerance_m=0, keep_properties=["Name"])
+
+    assert outcome.result.feature_count == 1
+    assert len(outcome.dataframe) == outcome.result.feature_count
+    assert list(outcome.dataframe["Name"]) == ["edge"]
 
 
 def test_multiple_adjacent_sorted_longest_first():
@@ -136,7 +158,7 @@ def test_multiple_adjacent_sorted_longest_first():
     result = adjacency(
         aoi=aoi, adapter=FakeAdapter(gdf), tolerance_m=0,
         feature_id_field="Id", keep_properties=["Name"],
-    )
+    ).result
     assert result.feature_count == 2
     measures = [f.measure for f in result.features]
     assert measures[0] > measures[1]                     # longest shared border first

--- a/ast_engine/tests/unit/test_execution.py
+++ b/ast_engine/tests/unit/test_execution.py
@@ -8,12 +8,16 @@ no BCGW connection is needed.
 What we check:
 - an end-to-end run over the three operators (overlay / within_distance /
   adjacency) returns the right AstResults shape and result types;
-- one dataset's failure is isolated: its group comes back empty and the rest of
-  the run still produces results;
+- one dataset's failure is isolated: its group comes back empty and marked
+  status="failure", and the rest of the run still produces results. A dataset
+  that ran but found nothing stays "success", so the two are told apart;
 - the per-task helpers route correctly (table for Oracle, path for files; the
   attribute filter is forwarded to the adapter);
 - the registry -> task mapper fills the task fields (and lower-cases the geometry
-  type), skips a dataset with no operator, and tags provenance across registries.
+  type), skips a dataset with no operator, and tags provenance across registries;
+- saving the spatial output: off by default, one GeoPackage per dataset when it
+  is on, nothing written for a dataset with no matches, and a failed write never
+  costs the analysis result.
 
 The AOI is the Test_Shape_A box (a rectangle in BC Albers / EPSG:3005).
 """
@@ -29,11 +33,13 @@ from ast_engine.core.execution import (
     AnalysisTask,
     _pick_adapter,
     _run_operator,
+    _safe_filename,
     _source_kwargs,
     build_tasks,
     run_analysis,
     tasks_from_registry,
 )
+from ast_engine.config.settings import Settings
 from ast_engine.core.results import (
     AdjacencyResult,
     AstResults,
@@ -172,8 +178,101 @@ def test_per_task_error_isolation():
     bad = next(g for g in result.results if g.dataset_name == "missing")
     good = next(g for g in result.results if g.dataset_name == "polys")
     assert bad.results == []                       # failure recorded as an empty group
+    assert bad.status == "failure"                 # ...and marked, so it is not read as "nothing found"
+    assert bad.error                               # with the reason kept for the analyst
     assert len(good.results) == 1                  # the good dataset still ran
+    assert good.status == "success"
+    assert good.error is None
     assert good.results[0].feature_count == 2
+
+
+def test_a_dataset_with_no_matches_is_a_success_not_a_failure():
+    """The empty-vs-failed check: nothing found still counts as a dataset that ran."""
+    far_point = DATA_DIR / "Test_Proximity" / "proximity_2_km.shp"
+    task = _file_task("1", "far", far_point, "within_distance", distance_m=100)
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=[task], job_id="job-7")
+
+    group = result.results[0]
+    assert group.status == "success"               # the read worked
+    assert group.error is None
+    assert group.results[0].feature_count == 0     # there was just nothing near the AOI
+
+
+# --- Saving the spatial output ----------------------------------------------
+# record_spatial is off by default; when it is on, each dataset's matched
+# features are saved as a GeoPackage under temp_dir and the file path is recorded
+# on the result as spatial_link.
+
+def _overlay_task() -> AnalysisTask:
+    """One polygon overlay task - 2 of the 3 test polygons match the AOI."""
+    return _file_task("1", "test polys", POLYGONS, "overlay", geom_type="polygon")
+
+
+def test_record_spatial_off_writes_nothing(tmp_path):
+    """The default: no files, and spatial_link stays empty."""
+    settings = Settings(record_spatial=False, temp_dir=str(tmp_path))
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=[_overlay_task()], job_id="job-3", settings=settings)
+
+    assert result.results[0].results[0].spatial_link is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_record_spatial_writes_a_gpkg_and_records_the_path(tmp_path):
+    """One GeoPackage per dataset, in a folder named after the analysis."""
+    settings = Settings(record_spatial=True, temp_dir=str(tmp_path))
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=[_overlay_task()], job_id="job-4", settings=settings)
+
+    # the space in "test polys" is replaced so the name works as a file name
+    written = tmp_path / "overlay" / "test_polys.gpkg"
+    assert written.exists()
+
+    saved = result.results[0].results[0]
+    assert saved.spatial_link == str(written)
+
+    # the features are saved as they were read - same count as the result
+    on_disk = gpd.read_file(written)
+    assert len(on_disk) == saved.feature_count
+    # the operator's working column is renamed on the way out, so what an analyst
+    # opens says what the number is and what unit it is in
+    assert "overlap_area_m2" in on_disk.columns
+    assert "_overlay_measure" not in on_disk.columns
+
+
+def test_record_spatial_skips_a_dataset_with_no_matches(tmp_path):
+    """Nothing found means nothing to save - no empty file, no link."""
+    far_point = DATA_DIR / "Test_Proximity" / "proximity_2_km.shp"
+    task = _file_task("1", "far", far_point, "within_distance", distance_m=100)
+    settings = Settings(record_spatial=True, temp_dir=str(tmp_path))
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=[task], job_id="job-5", settings=settings)
+
+    assert result.results[0].results[0].feature_count == 0
+    assert result.results[0].results[0].spatial_link is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_failed_write_keeps_the_analysis_result(tmp_path, monkeypatch):
+    """A file that cannot be written is logged and skipped - the result survives."""
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(gpd.GeoDataFrame, "to_file", boom)
+    settings = Settings(record_spatial=True, temp_dir=str(tmp_path))
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=[_overlay_task()], job_id="job-6", settings=settings)
+
+    saved = result.results[0].results[0]
+    assert saved.feature_count == 2        # the analysis still came through
+    assert saved.spatial_link is None      # but nothing was saved
+
+
+def test_safe_filename_cleans_registry_names():
+    """Registry names carry spaces and brackets; the file name keeps only safe characters."""
+    assert _safe_filename("Indian Reserves (Tab 1)") == "Indian_Reserves_Tab_1"
+    assert _safe_filename("///") == "dataset"
 
 
 # --- Routing helpers --------------------------------------------------------

--- a/ast_engine/tests/unit/test_execution.py
+++ b/ast_engine/tests/unit/test_execution.py
@@ -269,6 +269,33 @@ def test_a_failed_write_keeps_the_analysis_result(tmp_path, monkeypatch):
     assert saved.spatial_link is None      # but nothing was saved
 
 
+def test_same_dataset_name_in_two_registries_writes_two_files(tmp_path):
+    """Two registries can carry the same dataset name - each keeps its own file.
+
+    Tab 1 is a selection of datasets that also sit in the provincial registry, so
+    a run covering both sees the same name twice. The registry folder is what
+    keeps the two outputs apart; without it the second write replaced the first.
+    """
+    tasks = [
+        _file_task("1", "Provincial Forest", POLYGONS, "overlay",
+                   geom_type="polygon", source_registry="tab1"),
+        _file_task("2", "Provincial Forest", POLYGONS, "overlay",
+                   geom_type="polygon", source_registry="provincial"),
+    ]
+    settings = Settings(record_spatial=True, temp_dir=str(tmp_path))
+
+    result = run_analysis(aoi=_valid_aoi(), tasks=tasks, job_id="job-7", settings=settings)
+
+    from_tab1 = tmp_path / "tab1" / "overlay" / "Provincial_Forest.gpkg"
+    from_provincial = tmp_path / "provincial" / "overlay" / "Provincial_Forest.gpkg"
+    assert from_tab1.exists()
+    assert from_provincial.exists()
+
+    # each result points at its own file, not at a shared one
+    links = [group.results[0].spatial_link for group in result.results]
+    assert links == [str(from_tab1), str(from_provincial)]
+
+
 def test_safe_filename_cleans_registry_names():
     """Registry names carry spaces and brackets; the file name keeps only safe characters."""
     assert _safe_filename("Indian Reserves (Tab 1)") == "Indian_Reserves_Tab_1"

--- a/ast_engine/tests/unit/test_overlay.py
+++ b/ast_engine/tests/unit/test_overlay.py
@@ -15,9 +15,12 @@ Purpose:
     - Non-overlapping features are dropped
     - Invalid AOIs are rejected
 
-Examples: 
+Examples:
 _valid_aoi()
 non_valid_aoi()
+
+Note: the operator returns an OperatorOutcome - the analysis result plus the
+features it was built from - so these tests read `.result` off the call.
 
 --------------------------------------------------------------------------
 """
@@ -85,7 +88,7 @@ def test_polygon_overlap_exact_values():
         adapter=FileSpatialAdapter(),
         keep_properties=["Name"],
         path=POLYGONS,
-    )
+    ).result
 
     assert test.feature_count == 2  # outside dropped
 
@@ -104,7 +107,7 @@ def test_line_overlap_exact_values():
         aoi=_valid_aoi(),
         adapter=FileSpatialAdapter(),
         path=POLYLINES,
-    )
+    ).result
 
     assert test.feature_count == 2
 
@@ -121,7 +124,7 @@ def test_point_overlay_count():
         aoi=_valid_aoi(),
         adapter=FileSpatialAdapter(),
         path=POINTS,
-    )
+    ).result
 
     assert test.feature_count == 2
     assert all(f.measure is None for f in test.features)
@@ -136,7 +139,7 @@ def test_sorted_descending_by_overlap():
         aoi=_valid_aoi(),
         adapter=FileSpatialAdapter(),
         path=POLYGONS,
-    )
+    ).result
 
     measures = [f.measure for f in test.features]
     assert measures == sorted(measures, reverse=True)
@@ -152,7 +155,7 @@ def test_zero_overlap_removed():
         aoi=_valid_aoi(),
         adapter=FileSpatialAdapter(),
         path=POLYGONS,
-    )
+    ).result
 
     assert all(f.measure > 0 for f in test.features)
 
@@ -167,7 +170,7 @@ def test_properties_preserved():
         adapter=FileSpatialAdapter(),
         keep_properties=["Name"],
         path=POLYGONS,
-    )
+    ).result
 
     names = [f.properties["Name"] for f in test.features]
     assert len(names) == test.feature_count
@@ -180,7 +183,7 @@ def test_feature_id_fallback():
         adapter=FileSpatialAdapter(),
         feature_id_field="NOT_REAL",
         path=POLYGONS,
-    )
+    ).result
 
     ids = [f.feature_id for f in test.features]
     assert len(set(ids)) == len(ids)
@@ -210,7 +213,7 @@ def test_build_results():
         feature_id_field="FID",
         keep_properties=["Name"],
         path = POINTS,
-    )
+    ).result
     # extract_properties: the Name column comes through for the points inside the AOI
     assert [f.properties.get("Name") for f in test.features] == ["First", "Second"]
     # extract_feature_id: no real "FID" column, so IDs fall back to distinct row numbers
@@ -283,7 +286,7 @@ def test_empty_returns_zero_area():
         adapter=adapter,
         geom_type="polygon",
         path=POLYGONS,
-    )
+    ).result
 
     assert test.total_area == 0.0
     assert test.features == []
@@ -334,7 +337,7 @@ def test_geom_type_override_returns_correct_result_types():
             adapter=FileSpatialAdapter(),
             geom_type=geom_type,
             path=path,
-        )
+        ).result
 
         assert isinstance(result, expected_type)
 

--- a/ast_engine/tests/unit/test_proximity.py
+++ b/ast_engine/tests/unit/test_proximity.py
@@ -32,6 +32,9 @@ def test_within_distance_keeps_closest_first()
 def test_nearest_k_limits_count()
 def test_nearest_max_distance_cap()
 
+Note: the operators return an OperatorOutcome - the analysis result plus the
+features it was built from - so these tests read `.result` off the call.
+
 """
 
 import pytest
@@ -90,7 +93,7 @@ def test_3_within_distance():
         feature_id_field="id",
         keep_properties=["name"],
         path = THREEM,
-    )
+    ).result
     #This is rounded because test data has some trailing decimals 
     assert round((test.measure_value), 2) == 3.0
 
@@ -104,7 +107,7 @@ def test_10_within_distance():
         feature_id_field="id",
         keep_properties=["name"],
         path = TENM,
-    )
+    ).result
     #This is rounded because test data has some trailing decimals 
     assert round((test.measure_value), 2) == 10.0
 
@@ -118,7 +121,7 @@ def test_2000_within_distance():
         feature_id_field="id",
         keep_properties=["name"],
         path = TWOKM,
-    )
+    ).result
     #This is rounded because test data has some trailing decimals 
     assert round((test.measure_value), 2) == 1999.25
 
@@ -133,7 +136,7 @@ def test_nearest_k():
         k=2,
         max_distance_m = 12,
         path = MULTIPOINT,
-    )
+    ).result
 
     assert test.feature_count == 2
 
@@ -160,7 +163,7 @@ def test_build_results_within_distance():
         feature_id_field="FID",
         keep_properties=["Colour"],
         path = MULTIPOINT,
-    )
+    ).result
     # extract_properties: the Colour column comes through (3 m point then 10 m point)
     assert [f.properties.get("Colour") for f in test.features] == ["Green", "Blue"]
     # extract_feature_id: no real "FID" column, so IDs fall back to distinct row numbers
@@ -176,7 +179,7 @@ def test_build_results_nearest():
         feature_id_field="FID",
         keep_properties=["Colour"],
         path = MULTIPOINT,
-    )
+    ).result
     # extract_properties: the Colour column comes through (3 m point then 10 m point)
     assert [f.properties.get("Colour") for f in test.features] == ["Green", "Blue"]
     # extract_feature_id: no real "FID" column, so IDs fall back to distinct row numbers
@@ -193,7 +196,7 @@ def test_far_point_excluded():
     """A point further than the search distance is dropped; empty result reports 0."""
     test = within_distance(
         aoi=_valid_aoi(), adapter=FileSpatialAdapter(), distance_m=5, path=TENM,
-    )
+    ).result
     assert test.feature_count == 0
     assert test.measure_value == 0.0
 
@@ -202,14 +205,14 @@ def test_within_distance_keeps_closest_first():
     """All three points in one layer: distance 12 keeps the 3 m + 10 m points, closest first."""
     test = within_distance(
         aoi=_valid_aoi(), adapter=FileSpatialAdapter(), distance_m=12, path=MULTIPOINT,
-    )
+    ).result
     assert test.feature_count == 2
     assert [round(f.measure, 2) for f in test.features] == [3.0, 10.0]
 
 
 def test_nearest_k_limits_count():
     """k=1 returns only the single closest point."""
-    test = nearest(aoi=_valid_aoi(), adapter=FileSpatialAdapter(), k=1, path=MULTIPOINT)
+    test = nearest(aoi=_valid_aoi(), adapter=FileSpatialAdapter(), k=1, path=MULTIPOINT).result
     assert test.feature_count == 1
     assert round(test.measure_value, 2) == 3.0
 
@@ -218,7 +221,7 @@ def test_nearest_max_distance_cap():
     """Ask for the 2 nearest but cap at 5 m - only the 3 m point qualifies."""
     test = nearest(
         aoi=_valid_aoi(), adapter=FileSpatialAdapter(), k=2, max_distance_m=5, path=MULTIPOINT,
-    )
+    ).result
     assert test.feature_count == 1
     assert round(test.measure_value, 2) == 3.0
 


### PR DESCRIPTION
## Description
This unfinished PR should add spatial output capture to the execution pipeline and introduces a generalized OperatorOutcome model so each operator can return both its structured analysis result and the underlying spatial GeoDataFrame used to compute it.

## TODO
1. make the _run_one_task update the spatial_link property of the AnalysisResult stored in the OperatorOutcome.result
2. adjust logging and timing around the _run_one_task file writing
3. update unit tests for true/false record_spatial use cases
4. complete pull request checklist



- [x]  resolves issue https://github.com/bcgov/automated-statusing-tool/issues/162

## Key changes
**All operators now return OperatorOutcome**

**Added OperatorOutcome in results.py**

Carries:
  status: success/failure
  result: typed analysis payload (overlay/proximity/adjacency result model)
  dataframe: the source GeoDataFrame for the analysis output


**Writing task results to disk**
_run_one_task() now checks whether spatial recording is enabled
When enabled, it writes result.dataframe to disk via _write_spatial(...)
Output is saved as a GeoPackage in a folder organized by operator name:
<temp_dir>/<operator_name>/<dataset_name>.gpkg

**Added config toggles in settings.py**
  record_spatial: bool = False
  temp_dir: str | None = None
  These controls allow the feature to remain opt-in and keep default runs unchanged unless explicitly configured

## Why this matters
The execution engine can now produce both:
machine-readable summary results for reporting and downstream processing
persisted spatial outputs for QA, review, and debugging
The result model is now richer and more flexible without forcing all operator logic to know about file IO details

## Example behavior
When:
record_spatial = True
temp_dir = "/tmp/ast_results"
the orchestrator writes each dataset’s output as a GeoPackage file such as:

/tmp/ast_results/overlay/my_dataset.gpkg
> Please provide Summary Request Here. Include:
> 1. Reference to the issue #
> 2. Description of the changes proposed

### Check List
- [ ] Code runs locally
- [ ] Tests pass
- [ ] New behavior has tests
- [ ] Documentation updated if behavior changed
- [ ] No secrets, credentials, or local-only paths committed
- [ ] Logging uses module-level loggers
- [ ] Exceptions and validation results follow engine convention

